### PR TITLE
Merge branch/21.08 into branch/22.08 (for go 1.20.1)

### DIFF
--- a/org.freedesktop.Sdk.Extension.golang.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.golang.appdata.xml
@@ -6,6 +6,7 @@
   <summary>Go compiler and tools</summary>
   <url type="homepage">https://golang.org/</url>
   <releases>
+    <release version="1.20.1" date="2023-02-14"/>
     <release version="1.19.5" date="2023-01-10"/>
     <release version="1.19.4" date="2022-12-06"/>
     <release version="1.19.3" date="2022-11-01"/>

--- a/org.freedesktop.Sdk.Extension.golang.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.golang.appdata.xml
@@ -6,6 +6,7 @@
   <summary>Go compiler and tools</summary>
   <url type="homepage">https://golang.org/</url>
   <releases>
+    <release version="1.19.5" date="2023-01-10"/>
     <release version="1.19.4" date="2022-12-06"/>
     <release version="1.19.3" date="2022-11-01"/>
     <release version="1.19.2" date="2022-10-04"/>

--- a/org.freedesktop.Sdk.Extension.golang.yaml
+++ b/org.freedesktop.Sdk.Extension.golang.yaml
@@ -13,8 +13,8 @@ modules:
       - type: archive
         only-arches:
           - aarch64
-        url: https://go.dev/dl/go1.19.5.linux-arm64.tar.gz
-        sha256: fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3
+        url: https://go.dev/dl/go1.20.1.linux-arm64.tar.gz
+        sha256: 5e5e2926733595e6f3c5b5ad1089afac11c1490351855e87849d0e7702b1ec2e
         x-checker-data:
           type: anitya
           project-id: 1227
@@ -23,8 +23,8 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://go.dev/dl/go1.19.5.linux-amd64.tar.gz
-        sha256: 36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
+        url: https://go.dev/dl/go1.20.1.linux-amd64.tar.gz
+        sha256: 000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
         x-checker-data:
           type: anitya
           project-id: 1227

--- a/org.freedesktop.Sdk.Extension.golang.yaml
+++ b/org.freedesktop.Sdk.Extension.golang.yaml
@@ -13,8 +13,8 @@ modules:
       - type: archive
         only-arches:
           - aarch64
-        url: https://go.dev/dl/go1.19.4.linux-arm64.tar.gz
-        sha256: 9df122d6baf6f2275270306b92af3b09d7973fb1259257e284dba33c0db14f1b
+        url: https://go.dev/dl/go1.19.5.linux-arm64.tar.gz
+        sha256: fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3
         x-checker-data:
           type: anitya
           project-id: 1227
@@ -23,8 +23,8 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
-        sha256: c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
+        url: https://go.dev/dl/go1.19.5.linux-amd64.tar.gz
+        sha256: 36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
         x-checker-data:
           type: anitya
           project-id: 1227


### PR DESCRIPTION
22.08 branch is out of date again (21.08 is still the default).
Fixes #82 