### PR TITLE
Append $HOME/go/bin to PATH

### DIFF
--- a/org.freedesktop.Sdk.Extension.golang.yaml
+++ b/org.freedesktop.Sdk.Extension.golang.yaml
@@ -38,7 +38,7 @@ modules:
       - type: script
         commands:
           - export GOROOT=/usr/lib/sdk/golang
-          - export PATH=$PATH:$GOROOT/bin
+          - export PATH=$PATH:$GOROOT/bin:$HOME/go/bin
         dest-filename: enable.sh
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Go packages are installed to $HOME/go/bin and users expect them to be in their PATH.